### PR TITLE
chore: update hapi deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release-major": "aegir release --type major --target node"
   },
   "dependencies": {
-    "content": "^4.0.6",
+    "@hapi/content": "^4.1.0",
     "dicer": "~0.3.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const content = require('content')
+const content = require('@hapi/content')
 const Parser = require('./parser')
 
 module.exports = {

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Dicer = require('dicer')
-const Content = require('content')
+const Content = require('@hapi/content')
 const stream = require('stream')
 const util = require('util')
 const Transform = stream.Transform


### PR DESCRIPTION
They moved to `@hapi` namespace and now spew warnings on npm install.

resolves #14
refs https://github.com/ipfs/js-ipfs/issues/2225